### PR TITLE
Добавить возможность собирать ядро через llvm.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,16 @@ endif
 CFLAGS = -fno-pic -ffreestanding -static -fno-builtin -fno-strict-aliasing \
 		 -Wall -ggdb -m32 -Werror -fno-omit-frame-pointer
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
+ASMFLAGS = -m32 -ffreestanding -c -g
+
+ifeq ($(LLVM),on)
+#AS=llvm-as
+LD=ld.lld
+CC=clang
+CFLAGS += -target elf-i386
+ASMFLAGS = -target elf-i386 -ffreestanding -c -g
+LDKERNELFLAGS = --script=script.ld
+endif
 
 run: image.bin
 	qemu-system-i386 -drive format=raw,file=$< -serial mon:stdio
@@ -41,6 +51,12 @@ debug-boot: image.bin mbr.elf
 		-ex "break *0x7c00" \
 		-ex "continue"
 
+debug-server: image.bin
+	qemu-system-i386 -drive format=raw,file=$< -s -S
+
+debug-server-nox: image.bin
+	qemu-system-i386 -nographic -drive format=raw,file=$< -s -S
+
 debug: image.bin
 	qemu-system-i386 -drive format=raw,file=$< -s -S &
 	$(GDB) kernel.bin \
@@ -67,13 +83,13 @@ image.bin: mbr.bin fs.img
 	cat $^ >$@
 
 kernel.bin: kernel.o console.o drivers/vga.o drivers/uart.o
-	$(LD) $(LDFLAGS) -o $@ -Ttext 0x1000 $^
+	$(LD) $(LDFLAGS) $(LDKERNELFLAGS) -o $@ -Ttext 0x1000 $^
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 %.o: %.S
-	$(CC) -m32 -ffreestanding -c -g $^ -o $@
+	$(CC) $(ASMFLAGS) $^ -o $@
 
 mbr.bin: mbr.o
 	$(LD) -m elf_i386 -Ttext=0x7c00 --oformat=binary $^ -o $@

--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
-Yet Another BootLoader, OS Kernel and Other stuff
+# Yet Another BootLoader, OS Kernel and Other stuff
 
-Quickstart:
+## Quickstart:
 ```
 $ ./setup.sh
 $ make
 ```
+## How to run using llvm
 
-Includes code from:
+You can use this way even if you have windows. You need to install llvm and qemu. 
+Check that executables `clang`, `ld.lld`, `qemu-system-i386` available from your terminal/console.
+
+```
+make LLVM=on
+```
+
+## How to debug in my favorite IDE
+
+Start debug server using command `make debug-server` or `make debug-server-nox` if you don't want to see gui, and 
+then connect using remote gdb option to localhost:1234 (symbols file is kernel.bin)
+
+## Includes code from:
 * https://github.com/mit-pdos/xv6-public
 * https://github.com/FRosner/FrOS
 * https://github.com/dhavalhirdhav/LearnOS

--- a/script.ld
+++ b/script.ld
@@ -1,0 +1,24 @@
+SECTIONS
+{
+.text (0x1000) : {
+ startup.o( .text )
+}
+
+.data : ALIGN(CONSTANT(MAXPAGESIZE)) {
+_DATA_START_ = .;
+ *(.data)
+_DATA_END_ = .;
+}
+
+.rodata : ALIGN(CONSTANT(MAXPAGESIZE)) {
+_RODATA_START_ = .;
+ *(.rodata)
+_RODATA_START_ = .;
+}
+
+.bss : ALIGN(CONSTANT(MAXPAGESIZE)) {
+_BSS_START_ = .;
+ *(.bss)
+_BSS_END_ = .;
+}
+}

--- a/script.ld
+++ b/script.ld
@@ -1,7 +1,13 @@
 SECTIONS
 {
 .text (0x1000) : {
- startup.o( .text )
+ *( .text )
+}
+
+.rodata : {
+_RODATA_START_ = .;
+ *(.rodata)
+_RODATA_START_ = .;
 }
 
 .data : ALIGN(CONSTANT(MAXPAGESIZE)) {
@@ -10,11 +16,6 @@ _DATA_START_ = .;
 _DATA_END_ = .;
 }
 
-.rodata : ALIGN(CONSTANT(MAXPAGESIZE)) {
-_RODATA_START_ = .;
- *(.rodata)
-_RODATA_START_ = .;
-}
 
 .bss : ALIGN(CONSTANT(MAXPAGESIZE)) {
 _BSS_START_ = .;


### PR DESCRIPTION
К сожалению, по дефолту ликер от llvm (ld.lld) добавляет смещения к адресам секций, в результате адреса и смещения не совпадают у всех секций, кроме .text, а в случае такого ядра это очень важно. Поэтому пришлось написать скрипт для ликера.

Также я добавил две дополнительные цели для запуска дебаг сервера без дебагера (для более удобной отладки в редакторах и IDE).